### PR TITLE
Fix: Add Manim to devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,6 +6,9 @@ RUN apt-get -y install git
 # For signed commits: https://code.visualstudio.com/remote/advancedcontainers/sharing-git-credentials#_sharing-gpg-keys
 RUN apt install gnupg2 -y
 
+# Install dependencies for manim
+RUN apt-get install -y build-essential pkg-config libcairo2-dev ffmpeg sox libpango1.0-dev
+
 # Install torch
 RUN pip install torch==2.4.1+cu121 --index-url https://download.pytorch.org/whl/cu121
 # pip install torch==2.4.1+cpu --index-url https://download.pytorch.org/whl/cpu # CPU only

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get -y install git
 RUN apt install gnupg2 -y
 
 # Install dependencies for manim
-RUN apt-get install -y build-essential pkg-config libcairo2-dev ffmpeg sox libpango1.0-dev
+RUN apt-get install -y build-essential python3-dev libcairo2-dev libpango1.0-dev ffmpeg
 
 # Install torch
 RUN pip install torch==2.4.1+cu121 --index-url https://download.pytorch.org/whl/cu121

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -37,5 +37,5 @@
 		"all"
 	],
 	// Install pathpyG as editable python package
-	"postCreateCommand": "pip install -e '.[dev,test,doc]' && git config --global --add safe.directory /workspaces/pathpyG"
+	"postCreateCommand": "pip install -e '.[dev,test,doc,vis]' && git config --global --add safe.directory /workspaces/pathpyG"
 }

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -35,3 +35,13 @@ If you want to install the latest development version, you can do so via pip dir
 ```bash
 pip install git+https://github.com/pathpy/pathpyG.git
 ```
+
+### Optional Visualisation Backends
+
+We provide multiple visualisation backends for PathpyG. The default backend [D3.js](https://d3js.org/) does not require any additional dependencies. We further provide a [Matplotlib](https://matplotlib.org/) backend that is installed by default. Additionally, we implemented a [Manim](https://www.manim.community/) backend that is not installed by default due to its dependencies that are required for installation. Please refer to the [Manim installation instructions](https://docs.manim.community/en/stable/installation/uv.html) for more information. Once installed, you can use the Manim backend for visualisation by setting the `backend` in the `PathpyG.plot` function to `manim`: 
+```python
+import pathpyg as pp
+
+t_graph = ...
+pp.plot(t_graph, backend='manim')
+```

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -42,6 +42,6 @@ We provide multiple visualisation backends for PathpyG. The default backend [D3.
 ```python
 import pathpyg as pp
 
-t_graph = ...
+t_graph = TemporalGraph.from_edge_list([('a', 'b', 1),('b', 'a', 3), ('b', 'c', 3)])
 pp.plot(t_graph, backend='manim')
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,10 @@ doc = [
     "mike"                                       # Tool for versioning the documentation
 ]
 
+vis = [
+    "manim", # Animation engine
+]
+
 [project.urls]
 Documentation = "https://www.pathpy.net"
 Source = "https://github.com/pathpy/pathpyG"


### PR DESCRIPTION
This PR adds the necessary dependencies to install `Manim` automatically during the devcontainer build. It also adds `Manim` as optional dependency with clarifications in the `Getting Started` Documentation page.