### PR TITLE
add features to customize the code reference

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -47,7 +47,7 @@ The documentation is then available at [`http://localhost:8000/`](http://localho
 
 ### Code Reference
 
-The `Code Reference` is generated automatically from the :python_logo: Python source files. The docstrings should be formatted according to the [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings). Be sure to also use the advanced stuff like notes, tips and more. They can e.g. look as follows:
+The `Code Reference` is generated automatically from the :python_logo: Python source files using `docs/gen_ref_pages.py`. The docstrings should be formatted according to the [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings). Be sure to also use the advanced stuff like notes, tips and more. They can e.g. look as follows:
 
 === "Docstring"
     ```python
@@ -70,7 +70,18 @@ The `Code Reference` is generated automatically from the :python_logo: Python so
 
 See the documentation of the underlying [griffe](https://mkdocstrings.github.io/griffe/docstrings/) package for more details.
 
-To get an overview for each module, `mkdocstrings` automatically uses the docstrings from the `__init__.py` files in each module as description. Thus, do not forget to add a docstring to each `__init__.py` file.
+To get an overview for each package, `mkdocstrings` automatically uses the docstrings from the `__init__.py` files in each package as description. Thus, do not forget to add a docstring to each `__init__.py` file. If a package starts with an underscore (`_`), the underscore will be removed from the name in the documentation. 
+
+#### Replace Automatic Code Reference 
+
+While the docstrings include rich functionality, it is easier to write long and detailed descriptions using `.md`-files. Therefore, you can replace the automatically generated documentation for a module by adding a `.md`-file with the same name as the module in the `docs/reference/`-directory. The file will be rendered instead of the automatically generated documentation. You can find an example in `docs/reference/pathpyG/index.md`.
+
+!!! info "Replacing package documentation in the `__init__.py`-file"
+    The Overview for each package can be provided in the `__init__.py`-file. If you want to replace the `__init__.py`-file to provide a better documentation using `markdown`, make sure to name the file `index.md` instead.
+
+#### Ignore specific `.py`-files
+
+If you want to ignore specific `.py`-files in the code reference, you can add them to `docs/reference/ignored_modules.yaml`. All files listed there will be ignored when generating the code reference. If you include all files in a package-directory, the whole package will not be shown in the documentation.
 
 ### Tutorials
 

--- a/docs/reference/ignored_modules.yaml
+++ b/docs/reference/ignored_modules.yaml
@@ -1,0 +1,9 @@
+- src/pathpyG/visualisations/_matplotlib/__init__.py
+- src/pathpyG/visualisations/_matplotlib/network_plots.py
+- src/pathpyG/visualisations/_matplotlib/core.py
+- src/pathpyG/visualisations/_tikz/__init__.py
+- src/pathpyG/visualisations/_tikz/network_plots.py
+- src/pathpyG/visualisations/_tikz/core.py
+- src/pathpyG/visualisations/_d3js/__init__.py
+- src/pathpyG/visualisations/_d3js/network_plots.py
+- src/pathpyG/visualisations/_d3js/core.py

--- a/docs/reference/pathpyG/index.md
+++ b/docs/reference/pathpyG/index.md
@@ -1,0 +1,13 @@
+# pathpyG
+
+pathpyG is an Open Source package facilitating next-generation network analytics and
+graph learning for time series data on graphs.
+
+Building on the industry-proven data structures and concepts of `pytorch`
+and `torch_geometric`, pathpyG makes it easier than ever to apply machine learning
+to temporal graph data.
+
+pathpyG is jointly developed at University of Wuerzburg, Princeton University,
+and University of Zurich. The research behind pathpyG has been funded by the
+Swiss National Science Foundation via 
+[grant 176938](https://data.snf.ch/grants/grant/176938).

--- a/src/pathpyG/__init__.py
+++ b/src/pathpyG/__init__.py
@@ -1,16 +1,3 @@
-"""pathpyG is an Open Source package facilitating next-generation network analytics and
-graph learning for time series data on graphs.
-
-Building on the industry-proven data structures and concepts of `pytorch`
-and `torch_geometric`, pathpyG makes it easier than ever to apply machine learning
-to temporal graph data.
-
-pathpyG is jointly developed at University of Wuerzburg, Princeton University,
-and University of Zurich. The research behind pathpyG has been funded by the
-Swiss National Science Foundation via 
-[grant 176938](https://data.snf.ch/grants/grant/176938).
-"""
-
 import torch
 
 __version__ = "0.2.0"


### PR DESCRIPTION
This PR adds some functionality to the documentation building workflow to 
- ignore specific `.py`-files in the `src/`-directory
- have the option to replace the documentation from the `docstrings` with an `.md`-file.